### PR TITLE
fix: embed web templates and static assets into the binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,8 +43,7 @@ archives:
       - README.md
       - LICENSE
       - config.yaml.example
-      - help/*
-      - web/**/*
+      - help/**/*
       - packaging/systemd/openvpn-mng.service
 
 checksum:
@@ -110,13 +109,15 @@ nfpms:
         dst: /usr/share/openvpn-mng/config.yaml.example
         type: config
 
-      # Web assets
-      - src: web/
-        dst: /usr/share/openvpn-mng/web/
+      # Web assets are embedded into the binary (see web/embed.go) —
+      # nothing to ship on disk.
 
       # Documentation
-      - src: help/
-        dst: /usr/share/doc/openvpn-mng/help/
+      # `type: tree` is required: without it nfpm flattens the directory
+      # and help/images/*.png would land next to the .md files.
+      - src: help
+        dst: /usr/share/doc/openvpn-mng/help
+        type: tree
 
       - src: README.md
         dst: /usr/share/doc/openvpn-mng/README.md
@@ -186,7 +187,6 @@ dockers_v2:
       org.opencontainers.image.revision: "{{ .FullCommit }}"
       org.opencontainers.image.licenses: "Apache-2.0"
     extra_files:
-      - web
       - config.yaml.example
 
 release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,6 @@ RUN apk --no-cache add ca-certificates tzdata
 # Copy binary from builder
 COPY --from=builder /app/openvpn-mng .
 
-# Copy web templates and static files
-COPY --from=builder /app/web ./web
-
 # Copy Swagger docs if they exist
 COPY --from=builder /app/docs ./docs
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -10,9 +10,6 @@ RUN apk --no-cache add ca-certificates tzdata
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/openvpn-mng .
 
-# Copy web templates and static files
-COPY web ./web
-
 # Copy example config
 COPY config.yaml.example ./config.yaml.example
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -1,6 +1,9 @@
 package routes
 
 import (
+	"html/template"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
@@ -8,15 +11,18 @@ import (
 	"github.com/tldr-it-stepankutaj/openvpn-mng/internal/handlers"
 	"github.com/tldr-it-stepankutaj/openvpn-mng/internal/middleware"
 	"github.com/tldr-it-stepankutaj/openvpn-mng/internal/models"
+	"github.com/tldr-it-stepankutaj/openvpn-mng/web"
 )
 
 // SetupRoutes sets up all routes
 func SetupRoutes(r *gin.Engine, cfg *config.Config, rateLimiter *middleware.RateLimiter, blacklist *middleware.TokenBlacklist) {
-	// Static files
-	r.Static("/static", "./web/static")
+	// Static files (embedded in the binary)
+	r.StaticFS("/static", http.FS(web.Static()))
 
-	// HTML templates
-	r.LoadHTMLGlob("web/templates/*")
+	// HTML templates (embedded in the binary)
+	r.SetHTMLTemplate(template.Must(
+		template.New("").Funcs(r.FuncMap).ParseFS(web.Templates(), "templates/*.html"),
+	))
 
 	// Handlers
 	authHandler := handlers.NewAuthHandler(&cfg.Auth, blacklist, &cfg.Security)

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,32 @@
+// Package web contains the embedded HTML templates and static assets
+// served by the web UI. Embedding them into the binary means packages
+// (rpm/deb), containers and plain binaries never depend on the process
+// working directory or on the assets being installed on disk.
+package web
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed templates/*.html
+var templatesFS embed.FS
+
+//go:embed static
+var staticFS embed.FS
+
+// Templates returns the embedded templates, rooted at the repository's web/
+// directory (i.e. patterns must be prefixed with "templates/").
+func Templates() fs.FS {
+	return templatesFS
+}
+
+// Static returns the embedded static assets, rooted at web/static.
+func Static() fs.FS {
+	sub, err := fs.Sub(staticFS, "static")
+	if err != nil {
+		// Only possible on a malformed embed pattern, which is a compile-time constant.
+		panic(err)
+	}
+	return sub
+}


### PR DESCRIPTION
The rpm/deb packages shipped web assets via nfpm 'src: web/', which flattens the directory tree, so /usr/share/openvpn-mng/web/templates/ never existed. On top of that the server resolved 'web/templates/*' relative to WorkingDirectory=/var/lib/openvpn-mng, so it could not have found them either way, and LoadHTMLGlob panicked on startup.

Assets are now embedded with go:embed, which makes packages, containers and plain binaries independent of the working directory. Also fixes the same flattening bug for the bundled help/ documentation (type: tree).

Fixes #5